### PR TITLE
Fix error when 3rd argument is not supplied to `Pathwise.prototype.put`

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,12 @@ Pathwise.prototype.put = function(path, obj, opts, fn){
     fn = opts;
     opts = {};
   }
+  if (!opts) {
+    opts = {};
+  }
+  if (!fn) {
+    fn = () => {};
+  }
   var batch = opts.batch || this._db.batch();
   this._write(batch, path, obj, fn);  
   if (opts.batch) setImmediate(fn);


### PR DESCRIPTION
Fixes following error:
```
...\node_modules\level-pathwise\index.js:23
  var batch = opts.batch || this._db.batch();
                   ^

TypeError: Cannot read property 'batch' of undefined
    at Pathwise.put (...\node_modules\level-pathwise\index.js:23:20)
```